### PR TITLE
Fix notify job of ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,8 +34,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: xt0rted/markdownlint-problem-matcher@v2
       - uses: DavidAnson/markdownlint-cli2-action@v7
-        with:
-          globs: "**/*.md"
 
   deny:
     runs-on: ubuntu-20.04
@@ -91,7 +89,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all --all-features --locked -- -D warnings
+          args: --all --all-features -- -D warnings
 
   build:
     runs-on: ubuntu-20.04
@@ -115,7 +113,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --locked
+          args: --release
 
   test:
     runs-on: ubuntu-20.04
@@ -139,7 +137,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release --locked
+          args: --release
 
   doc:
     runs-on: ubuntu-20.04
@@ -162,7 +160,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --release --locked --no-deps --features sim
+          args: --release --no-deps
 
   coverage:
     runs-on: ubuntu-20.04
@@ -195,7 +193,6 @@ jobs:
       - sort
       - clippy
       - build
-      - build-no-alloc
       - test
       - doc
       - coverage

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,14 @@
+{
+  // Disable some built-in rules
+  "config": {
+    "line-length": false,
+    "no-duplicate-header": {
+        // Allow multiple "Added" sections in the changelog
+        "siblings_only": true
+    }
+  },
+
+  // Define glob expressions to use (only valid at root)
+  "globs": ["**/*.md"],
+  "ignores": [".github/pull_request_template.md"]
+}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 -->[![Dependency Status][deps-image]][deps-link]<!--
 -->[![CodeCov Status][codecov-image]][codecov-link]<!--
 -->[![GitHub Workflow Status][gha-image]][gha-link]<!--
--->[![Contributor Covenant][conduct-image]](CODE_OF_CONDUCT.md) 
+-->[![Contributor Covenant][conduct-image]][conduct-link]
 
 This repository contains MobileCoin's implementations of functionality that exists in Rust's `libstd`. It is not organized as a single crate, but rather as a collection of crates that provide some required/obvious functionality, in particular the requisite language items
 
@@ -22,3 +22,4 @@ This repository contains MobileCoin's implementations of functionality that exis
 [gha-image]: https://img.shields.io/github/workflow/status/mobilecoinfoundation/sgx-std/rust/main?style=flat-square
 [gha-link]: https://github.com/mobilecoinfoundation/sgx-std/actions/workflows/build.yaml?query=branch%3Amain
 [conduct-image]: https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=flat-square
+[conduct-link]: CODE_OF_CONDUCT.md

--- a/alloc/Cargo.toml
+++ b/alloc/Cargo.toml
@@ -11,5 +11,4 @@ description = "Allocator for SGX enclave"
 categories = ["hardware-support", "no-std"]
 keywords = ["sgx", "no-std", "alloc"]
 
-
 [dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,50 @@
+targets = []
+
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "warn"
+notice = "warn"
+ignore = []
+
+[licenses]
+unlicensed = "deny"
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-3-Clause",
+    "ISC",
+    "MIT",
+    "Unicode-DFS-2016",
+]
+deny = []
+copyleft = "deny"
+allow-osi-fsf-free = "neither"
+default = "deny"
+confidence-threshold = 0.8
+exceptions = []
+
+[bans]
+multiple-versions = "warn"
+# Lint level for when a crate version requirement is `*`
+wildcards = "deny"
+highlight = "all"
+allow = []
+deny = [
+    # https://github.com/briansmith/ring/issues/774
+    { name = "ring" },
+]
+skip-tree = [ ]
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+
+[sources.allow-org]
+github = []
+gitlab = []
+bitbucket = []


### PR DESCRIPTION
The notify step was depending on the non existent `build-no-alloc` job.
This dependency has been removed
