### PR TITLE
Add CI steps for `mc-sgx-panic-abort`

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,14 @@ updates:
     interval: daily
   open-pull-requests-limit: 25
 
+  # See https://github.com/dependabot/dependabot-core/issues/2824 for doing
+  # multiple directories for the same check.
+- package-ecosystem: cargo
+  directory: "/panic/abort"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 25
+
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,8 @@ jobs:
           components: rustfmt
       - uses: r7kamura/rust-problem-matchers@v1
       - run: cargo +${{ matrix.rust }} fmt --all -- --check
+      - run: cargo +${{ matrix.rust }} fmt --all -- --check
+        working-directory: panic/abort
 
   markdown-lint:
     runs-on: ubuntu-22.04
@@ -61,6 +63,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: cargo install cargo-sort
       - run: cargo sort --workspace --check >/dev/null
+      - run: cargo sort --workspace --check >/dev/null
+        working-directory: panic/abort
 
   clippy:
     runs-on: ubuntu-22.04
@@ -79,6 +83,8 @@ jobs:
           components: clippy
       - uses: r7kamura/rust-problem-matchers@v1
       - run: cargo +${{ matrix.rust }} clippy --all --all-features -- -D warnings
+      - run: cargo +${{ matrix.rust }} clippy --all --all-features -- -D warnings
+        working-directory: panic/abort
 
   build:
     runs-on: ubuntu-22.04
@@ -99,6 +105,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - uses: r7kamura/rust-problem-matchers@v1
       - run: cargo +${{ matrix.rust }} build --release
+      - run: cargo +${{ matrix.rust }} build --release
+        working-directory: panic/abort
 
   test:
     runs-on: ubuntu-22.04
@@ -136,6 +144,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - uses: r7kamura/rust-problem-matchers@v1
       - run: cargo +${{ matrix.rust }} doc --release --no-deps
+      - run: cargo +${{ matrix.rust }} doc --release --no-deps
+        working-directory: panic/abort
 
   coverage:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
`mc-sgx-panic-abort` is a crate that that can only be built in a no_std
environment and thus can't use `cargo test`. Because of this
`mc-sgx-panic-abort` is separate from the root workspace and needs to be
explicitly called out in CI steps.

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

