### PR TITLE
Update CI to be n'sync with template repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mobilecoinfoundation/coredev

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,11 @@
+addReviewers: true
+addAssignees: author
+reviewers:
+  - jcape
+  - nick-mobilecoin
+  - awygle
+  - NotGyro
+  - samdealy
+  - varsha888
+
+numberOfReviewers: 2

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,6 +5,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 25
+  commit-message:
+    prefix: "chore(deps)"
 
   # See https://github.com/dependabot/dependabot-core/issues/2824 for doing
   # multiple directories for the same check.
@@ -13,9 +15,13 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 25
+  commit-message:
+    prefix: "chore(deps)"
 
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  commit-message:
+    prefix: "chore(deps)"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,3 +5,8 @@ rust:
 
 dependencies:
   - '**/Cargo.lock'
+
+github_actions:
+  - '.github/workflows/**'
+  - '.github/labeler.yml'
+  - '.github/triage-labeler.yml'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,19 +14,14 @@ env:
 jobs:
   rustfmt:
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        rust:
-          - nightly-2022-07-22
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ matrix.rust }}
           components: rustfmt
       - uses: r7kamura/rust-problem-matchers@v1
-      - run: cargo +${{ matrix.rust }} fmt --all -- --check
-      - run: cargo +${{ matrix.rust }} fmt --all -- --check
+      - run: cargo fmt --all -- --check
+      - run: cargo fmt --all -- --check
         working-directory: panic/abort
 
   markdown-lint:
@@ -49,7 +44,7 @@ jobs:
     # Prevent sudden announcement of a new advisory from failing ci:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: EmbarkStudios/cargo-deny-action@v1
       with:
         command: check ${{ matrix.checks }}
@@ -177,6 +172,7 @@ jobs:
     needs:
       - rustfmt
       - markdown-lint
+      - deny
       - sort
       - clippy
       - build

--- a/.github/workflows/copyright.yaml
+++ b/.github/workflows/copyright.yaml
@@ -1,4 +1,4 @@
-name: Update copyright year(s) in license file
+name: copyright
 
 on:
   schedule:

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -1,4 +1,4 @@
-name: issues-meta
+name: issues
 
 on:
   issues:

--- a/.github/workflows/pr-assign.yaml
+++ b/.github/workflows/pr-assign.yaml
@@ -1,0 +1,13 @@
+name: pr-assign
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.2.4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,4 +1,4 @@
-name: pr-meta
+name: pr
 
 on:
   pull_request:
@@ -15,6 +15,7 @@ jobs:
   size-label:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - uses: pascalgn/size-label-action@v0.4.3
@@ -41,4 +42,3 @@ jobs:
     - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: true


### PR DESCRIPTION
Brings in:
- pr assignment
- codeowners (actual group name)
- standardizes some naming of jobs/workflows

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

