### PR TITLE
Add `mc-sgx-panic-log`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,8 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo fmt --all -- --check
         working-directory: panic/abort
+      - run: cargo fmt --all -- --check
+        working-directory: panic/log
 
   markdown-lint:
     runs-on: ubuntu-22.04
@@ -60,6 +62,8 @@ jobs:
       - run: cargo sort --workspace --check >/dev/null
       - run: cargo sort --workspace --check >/dev/null
         working-directory: panic/abort
+      - run: cargo sort --workspace --check >/dev/null
+        working-directory: panic/log
 
   clippy:
     runs-on: ubuntu-22.04
@@ -83,6 +87,8 @@ jobs:
       - run: cargo +${{ matrix.rust }} clippy --all --all-features -- -D warnings
       - run: cargo +${{ matrix.rust }} clippy --all --all-features -- -D warnings
         working-directory: panic/abort
+      - run: cargo +${{ matrix.rust }} clippy --all --all-features -- -D warnings
+        working-directory: panic/log
 
   build:
     runs-on: ubuntu-22.04
@@ -107,6 +113,8 @@ jobs:
       - run: cargo +${{ matrix.rust }} build --release
       - run: cargo +${{ matrix.rust }} build --release
         working-directory: panic/abort
+      - run: cargo +${{ matrix.rust }} build --release
+        working-directory: panic/log
 
   test:
     runs-on: ubuntu-22.04
@@ -151,6 +159,8 @@ jobs:
       - run: cargo +${{ matrix.rust }} doc --release --no-deps
       - run: cargo +${{ matrix.rust }} doc --release --no-deps
         working-directory: panic/abort
+      - run: cargo +${{ matrix.rust }} doc --release --no-deps
+        working-directory: panic/log
 
   coverage:
     runs-on: ubuntu-22.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
 ]
 exclude = [
     "panic/abort",
+    "panic/log",
     "test_enclave",
 ]
 

--- a/panic/log/Cargo.toml
+++ b/panic/log/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "mc-sgx-panic-log"
+version = "0.1.0"
+edition = "2021"
+authors = ["MobileCoin"]
+rust-version = "1.62.1"
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/mobilecoinfoundation/sgx-std"
+description = "Panic handler for an SGX enclave that logs to the untrusted (host)"
+categories = ["hardware-support", "no-std"]
+keywords = ["sgx", "no-std", "panic"]
+
+[dependencies]
+mc-sgx-io = { path = "../../io", version = "0.1.0" }

--- a/panic/log/README.md
+++ b/panic/log/README.md
@@ -1,0 +1,21 @@
+# MobileCoin SGX: Panic handler that logs to untrusted (host)
+
+[![Project Chat][chat-image]][chat-link]<!--
+-->![License][license-image]<!--
+-->![Target][target-image]<!--
+-->[![Crates.io][crate-image]][crate-link]<!--
+-->[![Docs Status][docs-image]][docs-link]<!--
+-->[![Dependency Status][deps-image]][deps-link]
+
+Panic handler for an SGX enclave that logs to the untrusted (host)
+
+[chat-image]: https://img.shields.io/discord/844353360348971068?style=flat-square
+[chat-link]: https://mobilecoin.chat
+[license-image]: https://img.shields.io/crates/l/mc-sgx-panic-log?style=flat-square
+[target-image]: https://img.shields.io/badge/target-sgx-red?style=flat-square
+[crate-image]: https://img.shields.io/crates/v/mc-sgx-panic-log.svg?style=flat-square
+[crate-link]: https://crates.io/crates/mc-sgx-panic-log
+[docs-image]: https://img.shields.io/docsrs/mc-sgx-panic-log?style=flat-square
+[docs-link]: https://docs.rs/crate/mc-sgx-panic-log
+[deps-image]: https://deps.rs/crate/mc-sgx-panic-log/0.1.0/status.svg?style=flat-square
+[deps-link]: https://deps.rs/crate/mc-sgx-panic-log/0.1.0

--- a/panic/log/src/lib.rs
+++ b/panic/log/src/lib.rs
@@ -1,0 +1,18 @@
+// Copyright (c) 2022 The MobileCoin Foundation
+
+#![doc = include_str!("../README.md")]
+#![deny(missing_docs, missing_debug_implementations)]
+#![no_std]
+
+extern crate alloc;
+use alloc::string::ToString;
+use core::panic::PanicInfo;
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    // Ignore the result, we're already panicking we can't really do much if
+    // `stderr_write_all()` fails
+    let _ = mc_sgx_io::stderr_write_all(info.to_string().as_bytes());
+
+    loop {}
+}


### PR DESCRIPTION
Add a panic handler that will log the panic info from an SGX enclave to
the host

### Future Work
Remove use of String for the `info` struct, added a task to #29 for this.

