### PR TITLE
Add `mc-sgx-panic` crate for common panic handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "alloc",
     "io",
     "io/untrusted",
+    "panic"
 ]
 exclude = [
     "panic/abort",

--- a/panic/Cargo.toml
+++ b/panic/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mc-sgx-panic"
+version = "0.1.0"
+edition = "2021"
+authors = ["MobileCoin"]
+rust-version = "1.62.1"
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/mobilecoinfoundation/sgx-std"
+description = "Common panic handling behavior for SGX enclaves"
+categories = ["hardware-support", "no-std"]
+keywords = ["sgx", "no-std", "panic"]
+
+[dependencies]

--- a/panic/README.md
+++ b/panic/README.md
@@ -1,0 +1,21 @@
+# MobileCoin: Common panic handling behavior for SGX enclaves
+
+[![Project Chat][chat-image]][chat-link]<!--
+-->![License][license-image]<!--
+-->![Target][target-image]<!--
+-->[![Crates.io][crate-image]][crate-link]<!--
+-->[![Docs Status][docs-image]][docs-link]<!--
+-->[![Dependency Status][deps-image]][deps-link]
+
+Common panic handling behavior for SGX enclaves
+
+[chat-image]: https://img.shields.io/discord/844353360348971068?style=flat-square
+[chat-link]: https://mobilecoin.chat
+[license-image]: https://img.shields.io/crates/l/mc-sgx-panic?style=flat-square
+[target-image]: https://img.shields.io/badge/target-sgx-red?style=flat-square
+[crate-image]: https://img.shields.io/crates/v/mc-sgx-panic.svg?style=flat-square
+[crate-link]: https://crates.io/crates/mc-sgx-panic
+[docs-image]: https://img.shields.io/docsrs/mc-sgx-panic?style=flat-square
+[docs-link]: https://docs.rs/crate/mc-sgx-panic
+[deps-image]: https://deps.rs/crate/mc-sgx-panic/0.1.0/status.svg?style=flat-square
+[deps-link]: https://deps.rs/crate/mc-sgx-panic/0.1.0

--- a/panic/abort/Cargo.toml
+++ b/panic/abort/Cargo.toml
@@ -11,6 +11,8 @@ description = "Panic handler for SGX enclaves that aborts"
 categories = ["hardware-support", "no-std"]
 keywords = ["sgx", "no-std", "panic"]
 
+[workspace]
+
 [dependencies]
 # To get link in the abort() function
 mc-sgx-trts-sys = "0.4.0"
@@ -32,4 +34,3 @@ tag-name = "v{{version}}"
 pre-release-replacements = [
     {file="README.md", search="mc-[a-z-]+/[0-9.]+", replace="{{crate_name}}/{{version}}"},
 ]
-

--- a/panic/log/Cargo.toml
+++ b/panic/log/Cargo.toml
@@ -11,5 +11,25 @@ description = "Panic handler for an SGX enclave that logs to the untrusted (host
 categories = ["hardware-support", "no-std"]
 keywords = ["sgx", "no-std", "panic"]
 
+[workspace]
+
 [dependencies]
 mc-sgx-io = { path = "../../io", version = "0.1.0" }
+
+# This is a crate that can only be built for an SGX target, so it's not part of
+# the root workspace. Because of this limitation we must re-iterate the
+# `cargo release` settings here
+[package.metadata.release]
+shared-version = true
+dev-version-ext = "beta.0"
+consolidate-commits = true
+consolidate-pushes = true
+tag-name = "v{{version}}"
+
+# The file names in this key are relative to the each crate that gets released.
+# So we only need one `README.md` entry if all the README's follow a
+# common format and are always next to the Cargo.toml for their respective
+# package.
+pre-release-replacements = [
+    {file="README.md", search="mc-[a-z-]+/[0-9.]+", replace="{{crate_name}}/{{version}}"},
+]

--- a/panic/src/lib.rs
+++ b/panic/src/lib.rs
@@ -1,0 +1,4 @@
+// Copyright (c) 2023 The MobileCoin Foundation
+#![doc = include_str!("../README.md")]
+#![deny(missing_docs, missing_debug_implementations, unsafe_code)]
+#![no_std]


### PR DESCRIPTION
This change is in preparation of the `mc-sgx-sync` crate, #29

In order to support Mutex poisoning there needs to be an implementation of `panicking()`, https://doc.rust-lang.org/src/std/sync/poison.rs.html#33
This panicking logic should probably be common such that it's not re-implemented for `mc-sgx-panic-abort` and `mc-sgx-panic-log`

It may be appropriate to only have `mc-sgx-panic` and then use features `abort` and `log` to specify the implementation to use. While features are inherently additive in Cargo it's not unheard of to use mutually exclusive features, https://doc.rust-lang.org/cargo/reference/features.html#mutually-exclusive-features