### PR TITLE
Prevent recursive panics from happening

### DIFF
--- a/panic/Cargo.toml
+++ b/panic/Cargo.toml
@@ -15,5 +15,6 @@ keywords = ["sgx", "no-std", "panic"]
 log = ["dep:mc-sgx-io", "dep:mc-sgx-sync"]
 
 [dependencies]
-mc-sgx-io = { path = "../io", version = "0.1.0", optional = true }
-mc-sgx-sync = { path = "../sync", version = "0.1.0", optional = true }
+mc-sgx-io = { path = "../io", version = "=0.1.0", optional = true }
+mc-sgx-panic-sys = { path = "sys", version = "=0.1.0" }
+mc-sgx-sync = { path = "../sync", version = "=0.1.0", optional = true }

--- a/panic/src/lib.rs
+++ b/panic/src/lib.rs
@@ -6,6 +6,8 @@
 
 #[cfg(not(test))]
 use core::panic::PanicInfo;
+#[cfg(not(test))]
+use mc_sgx_panic_sys::panic_count;
 
 #[cfg(feature = "log")]
 mod log;
@@ -13,12 +15,21 @@ mod log;
 #[cfg(not(test))]
 #[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {
-    #[cfg(feature = "log")]
-    log::log_panic_info(_info);
-
     extern "C" {
         fn abort() -> !;
     }
+
+    let panics = panic_count::increase();
+
+    // If we entered the panic handler more than once then we must have panicked
+    // while trying to handle the panic. Fail hard in these instances, nothing
+    // more we can do.
+    if panics > 1 {
+        unsafe { abort() }
+    }
+
+    #[cfg(feature = "log")]
+    log::log_panic_info(_info);
 
     unsafe { abort() }
 }

--- a/panic/sys/src/lib.rs
+++ b/panic/sys/src/lib.rs
@@ -6,3 +6,4 @@
 
 mod panicking;
 pub mod thread;
+pub use panicking::panic_count;

--- a/panic/sys/src/panicking.rs
+++ b/panic/sys/src/panicking.rs
@@ -13,7 +13,7 @@ pub(crate) fn panicking() -> bool {
     !panic_count::count_is_zero()
 }
 
-pub(crate) mod panic_count {
+pub mod panic_count {
     //! Number of panics that are currently being handled on the current thread
     //!
     //! This deviates from


### PR DESCRIPTION
Previously if a panic occured while processing a panic the logic would
get stuck in a loop trying to handle the panic.
Now if a panic happens while processing a panic, a hard abort is
immediately executed.

