### PR TITLE
Remove unneeded traits on sys types

### DIFF
--- a/sync/src/sys/locks/condvar.rs
+++ b/sync/src/sys/locks/condvar.rs
@@ -10,9 +10,6 @@ pub(crate) struct Condvar {
     inner: SgxCondvar,
 }
 
-unsafe impl Send for Condvar {}
-unsafe impl Sync for Condvar {}
-
 impl Condvar {
     pub const fn new() -> Self {
         Self {

--- a/sync/src/sys/locks/mutex.rs
+++ b/sync/src/sys/locks/mutex.rs
@@ -12,9 +12,6 @@ pub(crate) struct Mutex {
     inner: SgxMutex,
 }
 
-unsafe impl Send for Mutex {}
-unsafe impl Sync for Mutex {}
-
 impl Mutex {
     /// Create a new Mutex
     pub(crate) const fn new() -> Mutex {

--- a/sync/src/sys/locks/rwlock.rs
+++ b/sync/src/sys/locks/rwlock.rs
@@ -16,9 +16,6 @@ pub(crate) struct RwLock {
     inner: SgxRwLock,
 }
 
-unsafe impl Send for RwLock {}
-unsafe impl Sync for RwLock {}
-
 impl RwLock {
     /// Create a new [`RwLock`]
     pub const fn new() -> RwLock {


### PR DESCRIPTION
Previously `Send` and `Sync` were declared on the sys versions of
`Mutex`, `RwLock`, and `Condvar`. Per
https://doc.rust-lang.org/nomicon/send-and-sync.html these traites are
automatically derived when composed entirely of `Send`/`Sync` types. The
types from `mc-sgx-tstdc` do derive `Send` and `Sync` so the redeclaring
of the traits here is unneeded.

