### PR TITLE
Exclude dtolnay/rust-toolchain from dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,27 +1,21 @@
+---
 version: 2
 updates:
-- package-ecosystem: cargo
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 25
-  commit-message:
-    prefix: "chore(deps)"
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "chore(deps)"
 
-  # See https://github.com/dependabot/dependabot-core/issues/2824 for doing
-  # multiple directories for the same check.
-- package-ecosystem: cargo
-  directory: "/panic/abort"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 25
-  commit-message:
-    prefix: "chore(deps)"
-
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  commit-message:
-    prefix: "chore(deps)"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "chore(deps)"
+    ignore:
+      # See https://github.com/dtolnay/rust-toolchain/issues/45 tags aren't used
+      # by rust-toolchain. Using a branch name will cause dependabot to suggest
+      # which ever branch happens to be the newest
+      - dependency-name: "rust-toolchain"


### PR DESCRIPTION
dtolnay/rust-toolchain uses branches to track and customize the github
action version and behavior.
This causes issues with dependabot which prefers release tags.
Dependabot will suggest using the newest branch. For example
dtolnay/rust-toolchain suggest using `@stable` to use the stable rust
version and to use `@master` with arguments to specify specific rust
versions. If the `stable` branch is newer than `master` dependabot will
make a pr to use `stable`, but this will break the intended behavior of
not using a `stable` rust version

