### PR TITLE
Update nightly to 2023-01-22

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -96,20 +96,20 @@ branches:
         #         rust:
         #           - stable
         #           - beta
-        #           - nightly-2023-01-04
+        #           - nightly-2023-01-22
         #
         # Then the matrix names would be:
         #   - "build (stable)"
         #   - "build (beta)"
-        #   - "build (nightly-2023-01-04)"
+        #   - "build (nightly-2023-01-22)"
         contexts:
           - lint
           - "deny (bans licenses sources)"
           - sort
           - "clippy (stable)"
-          - "build (nightly-2023-01-04)"
-          - "test (nightly-2023-01-04)"
-          - "coverage (nightly-2023-01-04)"
+          - "build (nightly-2023-01-22)"
+          - "test (nightly-2023-01-22)"
+          - "coverage (nightly-2023-01-22)"
       enforce_admins: true
       required_linear_history: true
       restrictions: null

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,10 +10,6 @@ name: ci
 env:
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-Dwarnings"
-  # This works around `dtolnay/rust-toolchain@master` it defaults to "sparse"
-  # when 1.68 is used, but the current nightly version (nightly-2023-01-04) is
-  # before the official support that doesn't use `-Z sparse`
-  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: "git"
 
 jobs:
   # TODO: Fix automatically
@@ -163,7 +159,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - nightly-2023-01-04
+          - nightly-2023-01-22
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -185,7 +181,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - nightly-2023-01-04
+          - nightly-2023-01-22
     steps:
       - uses: actions/checkout@v3
         with:
@@ -206,7 +202,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - nightly-2023-01-04
+          - nightly-2023-01-22
     steps:
       - uses: actions/checkout@v3
         with:
@@ -227,7 +223,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - nightly-2023-01-04
+          - nightly-2023-01-22
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
@@ -243,7 +239,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - nightly-2023-01-04
+          - nightly-2023-01-22
     steps:
       - uses: actions/checkout@v3
         with:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-01-04"
+channel = "nightly-2023-01-22"
 components = [ "clippy", "rustfmt" ]


### PR DESCRIPTION
Previously the nightly used was 2023-01-04. This was in the middle of
rust 1.68 development and lacked the sparse checkout support for
crates.io. A number of tools keyed of version 1.68 to determine when to
set sparse checkout, resulting in failures to access crates.io. Now
nightly 2023-01-22 is used, which is the last nightly for version 1.68
and contains the sparse checkout support.

