### PR TITLE
Fix ci branch protection for clippy build

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -106,7 +106,7 @@ branches:
           - lint
           - "deny (bans licenses sources)"
           - sort
-          - "clippy (stable)"
+          - "clippy (nightly-2023-01-22)"
           - "build (nightly-2023-01-22)"
           - "test (nightly-2023-01-22)"
           - "coverage (nightly-2023-01-22)"


### PR DESCRIPTION
Previously the clippy build requirement was `clippy (stable)`. Now it's
been fixed to be `clippy (nightly-2023-01-22)`

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->
